### PR TITLE
Improvement: better VAAs typing

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -219,15 +219,23 @@ export interface IVAAsCount {
   pagination: Pagination;
 }
 
-export interface IVAAInput extends TSortOptions {
-  chainId: number;
-  emitter?: string;
-  specific?: {
-    sequence: number;
-    signer: string;
-    hash: string;
-  };
-}
+type IVAAInputs =
+  | {
+      chainId: number;
+      emitter?: undefined;
+      specific?: undefined;
+    }
+  | {
+      chainId: number;
+      emitter: string;
+      specific?: {
+        sequence: number;
+        signer: string;
+        hash: string;
+      };
+    };
+
+export type IVAAInput = IVAAInputs & TSortOptions;
 
 export interface IVAA {
   data: TVAA[];


### PR DESCRIPTION
### Description

For the "specific VAA" endpoint, we should always receive the `chainId` parameter, after that we can optionally receive the `emitter` parameter, and after that we can optionally receive the `specific` parameter.

> chainId --> emitter --> specific

The problem? Our typing was accepting the `specific` as valid even if `emitter` parameter was not there.

> chainId --> specific

This PR fixes that.

Before

https://user-images.githubusercontent.com/41705567/216064972-7828d163-8b2c-4552-a46f-14a7f1825b46.mov

After

https://user-images.githubusercontent.com/41705567/216064997-c6604bb4-e10f-4e07-a63a-4a25fdb4265e.mov

